### PR TITLE
(fixes deprecation warning) update version tag to be a proper version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project (nor MinecraftAuthentication as a whole) is associated or endorsed 
     <dependency>
         <groupId>me.minecraftauth</groupId>
         <artifactId>lib</artifactId>
-        <version>LATEST</version>
+        <version>1.0.1</version>
     </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
`LATEST` is a deprecated version tag in Maven, so I've updated the version to the latest current version