### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MinecraftAuth/lib
 This is a Java library for querying the [minecraftauth.me](https://minecraftauth.me) service.
 
-This project (nor MinecraftAuthentication as a whole) is associated or endorsed by Minecraft/Mojang.
+Neither this project (nor MinecraftAuthentication as a whole) is associated nor endorsed by Minecraft/Mojang.
 
 # Maven [![Latest release](https://img.shields.io/github/release/MinecraftAuthentication/lib.svg)](https://github.com/MinecraftAuthentication/lib/releases/latest)
 ```xml


### PR DESCRIPTION
The readme has a (imo bad) typo that makes it sound like as if this project is actually endorsed by Mojang/Microsoft.

...weird how a missing "nor" and "Neither" can change the meaning of stuff...