### PR TITLE
Some pom fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,32 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.1.0</version>
                 <executions>
@@ -47,20 +73,31 @@
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <minimizeJar>true</minimizeJar>
-
-                            <filters>
-                                <filter>
-                                    <artifact>github.scarsz:configuralize</artifact>
-                                    <excludes>
-                                        <!-- snakeyaml and json simple is already inside craftbukkit -->
-                                        <exclude>org/yaml/snakeyaml/**</exclude>
-                                        <exclude>org/json/simple/**</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
+                            <!-- Don't overwrite the standard jar, instead make a -shaded jar -->
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <!-- maven-shade-plugin doesn't respect the root project's finalName -->
+                            <finalName>${project.build.finalName}-shaded</finalName>
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -98,13 +135,20 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>16.0.1</version>
+            <version>23.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
             <version>1.1.1</version>
+            <exclusions>
+                <exclusion>
+                    <!-- junit is a test dependency, but is a compile scoped transitive dependency in json-simple -->
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Added source & javadoc jars, as it's good practice to have those
- Changed shaded jar to have a -shaded classifier as the base jar is required to make the maven deployment sane
- Removed configuralize filter from shade plugin as configuralize isn't being used
- Added the git plugin for the ${git.commit.id.abbrev} property (being used in the manifest)
- Updated jetbrains annotations to 23.0.0
- Excluded junit from being included as a compile scoped dependency

Tested that this deploys correctly to maven local with `install` so deployment to repository should work fine too, and I guess the workflow uses the maven deployed artifacts already so it shouldn't care either